### PR TITLE
Updated gulp-sass Devdependency to fix bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "devDependencies": {
     "gulp": "^3.8.8",
-    "gulp-sass": "^0.7.3",
+    "gulp-sass": "^2.1.0",
     "browser-sync": "^1.3.7",
     "gulp-autoprefixer": "1.0.0"
   },


### PR DESCRIPTION
Was getting loads of errors with node-sass and gulp-sass after I ran npm install. I changed the dependency to the latest version 2.1.0 and now it works fine.