### PR TITLE
Prevent stopping server when sass has error.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,9 +41,9 @@ gulp.task('browser-sync', ['sass', 'jekyll-build'], function() {
 gulp.task('sass', function () {
     return gulp.src('_scss/main.scss')
         .pipe(sass({
-            includePaths: ['scss'],
-            onError: browserSync.notify
+            includePaths: ['scss']
         }))
+        .on('error', sass.logError)
         .pipe(prefix(['last 15 versions', '> 1%', 'ie 8', 'ie 7'], { cascade: true }))
         .pipe(gulp.dest('_site/css'))
         .pipe(browserSync.reload({stream:true}))


### PR DESCRIPTION
This prevents browser-sync from stopping when sass has errors. It just prints the error and server keeps running.
