### PR TITLE
Log sass error and notify browserSync

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,8 @@ var cp          = require('child_process');
 
 var jekyll   = process.platform === 'win32' ? 'jekyll.bat' : 'jekyll';
 var messages = {
-    jekyllBuild: '<span style="color: grey">Running:</span> $ jekyll build'
+    jekyllBuild: '<span style="color: grey">Running:</span> $ jekyll build',
+    sassError: 'Error in sass'
 };
 
 /**
@@ -43,8 +44,9 @@ gulp.task('sass', function () {
     return gulp.src('_scss/main.scss')
         .pipe(sass({
             includePaths: ['scss'],
-            onError: browserSync.notify
+            onError: browserSync.notify(messages.sassError)
         }))
+        .on('error', sass.logError)
         .pipe(prefix(['last 15 versions', '> 1%', 'ie 8', 'ie 7'], { cascade: true }))
         .pipe(gulp.dest('_site/css'))
         .pipe(browserSync.reload({stream:true}))


### PR DESCRIPTION
Amend PR #32. Log sass error to console and notify browserSync. Also prevents stopping browserSync server.
